### PR TITLE
修复ReactionTargetType在Deserialization的时候报错的bug

### DIFF
--- a/QQChannelSharp/Enumerations/ReactionTargetType.cs
+++ b/QQChannelSharp/Enumerations/ReactionTargetType.cs
@@ -1,4 +1,6 @@
-﻿namespace QQChannelSharp.Enumerations
+﻿using System.Runtime.Serialization;
+
+namespace QQChannelSharp.Enumerations
 {
     /// <summary>
     /// 表情表态对象类型
@@ -8,18 +10,22 @@
         /// <summary>
         /// 消息
         /// </summary>
+        [EnumMember(Value = "ReactionTargetType_MSG")]
         Msg = 0,
         /// <summary>
         /// 帖子
         /// </summary>
+        [EnumMember(Value = "ReactionTargetType_FEED")]
         Feed = 1,
         /// <summary>
         /// 评论
         /// </summary>
+        [EnumMember(Value = "ReactionTargetType_COMMNENT")] // 有错字, 应该是 ReactionTargetType_COMMENT
         Comment = 2,
         /// <summary>
         /// 回复
         /// </summary>
+        [EnumMember(Value = "ReactionTargetType_REPLY")]
         Reply = 3,
     }
 }

--- a/QQChannelSharp/Enumerations/ReactionTargetType.cs
+++ b/QQChannelSharp/Enumerations/ReactionTargetType.cs
@@ -1,10 +1,12 @@
 ﻿using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace QQChannelSharp.Enumerations
 {
     /// <summary>
     /// 表情表态对象类型
     /// </summary>
+    [JsonConverter(typeof(JsonStringEnumMemberConverter))]
     public enum ReactionTargetType
     {
         /// <summary>

--- a/QQChannelSharp/QQChannelSharp.csproj
+++ b/QQChannelSharp/QQChannelSharp.csproj
@@ -27,6 +27,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<PackageReference Include="Macross.Json.Extensions" Version="3.0.0" />
 		<PackageReference Include="RestSharp" Version="110.2.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
新加了依赖项 ``Macross.Json.Extensions``, 因为原生的Json库不支持把特定的string转换成enum 